### PR TITLE
Fix issue:Prerequisite check failed with git 2.16.3

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -145,7 +145,7 @@ $(eval $(call SetupHostCommand,svn,Please install the Subversion client, \
 	svn --version | grep Subversion))
 
 $(eval $(call SetupHostCommand,git,Please install Git (git-core) >= 1.6.5, \
-	git clone 2>&1 | grep -- --recursive))
+	git --version))
 
 $(eval $(call SetupHostCommand,file,Please install the 'file' package, \
 	file --version 2>&1 | grep file))


### PR DESCRIPTION
Fix the Prerequisite check failure problem.

Build dependency: Please install Git (git-core) >= 1.6.5

Prerequisite check failed. Use FORCE=1 to override.
make: *** [/home/USER/openwrt.git/include/toplevel.mk:142: staging_dir/host/.prereq-build] Error 1

Thanks to :https://forum.openwrt.org/viewtopic.php?id=72407